### PR TITLE
Adds automated installer build from AppVeyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,5 @@ gradle-app.setting
 .vscode/
 
 setup/
+
+!buildInstaller.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -224,5 +224,6 @@ gradle-app.setting
 .vscode/
 
 setup/
+temp/
 
 !buildInstaller.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,5 @@ gradle-app.setting
 
 #VSCode
 .vscode/
+
+setup/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ version: '{branch}-{build}'
 pull_requests:
   do_not_increment_build_number: true
 skip_branch_with_pr: true
+branches:
+  only:
+  - master
 build_script:
 - ps: >-
     ./buildInstaller.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: '{branch}-{build}'
+pull_requests:
+  do_not_increment_build_number: true
+skip_branch_with_pr: true
+build_script:
+- ps: >-
+    .\buildInstaller.ps1
+
+    Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
+    Get-ChildItem .\release\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
+    Get-ChildItem .\release\*.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ build_script:
 
     Get-ChildItem .\setup\Output\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
+deploy:
 - provider: GitHub
   auth_token:
     secure: iRYg7BaJ7cJ9OB18xvaOhmmhSZjN48FU2/2tB6K3qyqY2ubxOJTF2yYowAzksBYo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ pull_requests:
 skip_branch_with_pr: true
 build_script:
 - ps: >-
-    .\buildInstaller.ps1
+    ./buildInstaller.ps1
 
     Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,3 +11,12 @@ build_script:
     Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
     Get-ChildItem .\setup\Output\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
+- provider: GitHub
+  auth_token:
+    secure: iRYg7BaJ7cJ9OB18xvaOhmmhSZjN48FU2/2tB6K3qyqY2ubxOJTF2yYowAzksBYo
+  artifact: /.*\.exe/
+  artifact: /.*\.zip/
+  on:
+    branch: master
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,4 @@ build_script:
 
     Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
-    Get-ChildItem .\release\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-
-    Get-ChildItem .\release\*.jar | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+    Get-ChildItem .\setup\Output\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,6 @@ version: '{branch}-{build}'
 pull_requests:
   do_not_increment_build_number: true
 skip_branch_with_pr: true
-branches:
-  only:
-  - master
 build_script:
 - ps: >-
     ./buildInstaller.ps1
@@ -21,5 +18,4 @@ deploy:
     secure: iRYg7BaJ7cJ9OB18xvaOhmmhSZjN48FU2/2tB6K3qyqY2ubxOJTF2yYowAzksBYo
   artifact: /.*\.exe/,/.*\.zip/
   on:
-    branch: master
     appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ build_script:
 - ps: >-
     ./buildInstaller.ps1
 
+    if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
+
     Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
     Get-ChildItem .\release\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,7 @@ build_script:
 - provider: GitHub
   auth_token:
     secure: iRYg7BaJ7cJ9OB18xvaOhmmhSZjN48FU2/2tB6K3qyqY2ubxOJTF2yYowAzksBYo
-  artifact: /.*\.exe/
-  artifact: /.*\.zip/
+  artifact: /.*\.exe/,/.*\.zip/
   on:
     branch: master
     appveyor_repo_tag: true

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.internal.os.OperatingSystem
 
 plugins {
     id 'net.ltgt.errorprone' version '0.0.8'
-    id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '1.4'
+    id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '1.6'
 }
 
 allprojects {
@@ -11,9 +11,13 @@ allprojects {
     }
 }
 
-ext.useDriver = false
+if (!hasProperty('releaseType')) {
+    WPILibVersion {
+        releaseType = 'official'
+    }
+}
 
-ext.compilerPrefixToUse = project.hasProperty('compilerPrefix') ? project.compilerPrefix : 'arm-frc-linux-gnueabi-'
+ext.useDriver = false
 
 ext.setupDefines = { project, binaries ->
     binaries.all {
@@ -26,48 +30,6 @@ ext.setupDefines = { project, binaries ->
 }
 
 apply from: "locations.gradle"
-
-ext.addUserLinks = { linker, targetPlatform, implLib ->
-    def libPattern = /.*((\\/|\\).*)+lib(?<libName>.+).(.+)$/
-    def libraryArgs = []
-    def libraryPath = file(driverLibraryLib).path
-
-    // adds all libraries found in the driver folder
-    def libraryTree = fileTree(libraryPath)
-    libraryTree.include '*.so'
-    libraryTree.include '*.a'
-
-    libraryTree.each { lib ->
-        def nameMatcher = (lib.path =~ libPattern)
-        if (nameMatcher[0].size() > 1) {
-            def name = nameMatcher.group('libName')
-            libraryArgs << '-l' + name
-        }
-    }
-    
-    if (implLib) {
-        // adds all libraries found in the impl folder
-        def implLibraryPath = file(cppLibraryLib).path
-        def implLibraryTree = fileTree(implLibraryPath)
-        implLibraryTree.include '*.so'
-        implLibraryTree.include '*.a'
-
-        implLibraryTree.each { lib ->
-            def nameMatcher = (lib.path =~ libPattern)
-            if (nameMatcher[0].size() > 1) {
-                def name = nameMatcher.group('libName')
-                libraryArgs << '-l' + name
-            }
-        }
-    }
-     
-    // Add all arguments
-    String architecture = targetPlatform.architecture
-    if (architecture.contains('arm')){
-        linker.args << '-L' + libraryPath
-        linker.args.addAll(libraryArgs)
-    }
-}
 
 apply from: "properties.gradle"
 
@@ -82,6 +44,8 @@ apply from: "java/java.gradle"
 task build
 
 apply from: "releases.gradle"
+
+apply from: "installer.gradle"
 
 task clean(type: Delete) {
     description = "Deletes the build directory"

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ task clean(type: Delete) {
 
 clean {
     delete releaseDir
+    delete setupDir
 }
 
 task wrapper(type: Wrapper) {

--- a/buildInstaller.ps1
+++ b/buildInstaller.ps1
@@ -1,0 +1,14 @@
+$exePath = "$env:USERPROFILE\innosetup-5.5.9-unicode.exe"
+ 
+Write-Host "Downloading InnoSetup 5.5.9..."
+(New-Object Net.WebClient).DownloadFile('http://files.jrsoftware.org/is/5/innosetup-5.5.9-unicode.exe', $exePath)
+ 
+Write-Host "Installing..."
+cmd /c start /wait $exePath /silent
+ 
+Write-Host "Installed InnoSetup 5.5.9" -ForegroundColor Green
+
+$env:PATH += ";C:\Program Files (x86)\Inno Setup 5"
+$env:PATH += ";C:\Program Files\Inno Setup 5"
+
+.\gradlew installer

--- a/buildInstaller.ps1
+++ b/buildInstaller.ps1
@@ -43,7 +43,7 @@ $env:PATH += ";C:\Program Files (x86)\Inno Setup 5"
 $env:PATH += ";C:\Program Files\Inno Setup 5"
 
 if ($env:APPVEYOR) {
-    .\gradlew installer -PtoolChainPath="$comp" -PjenkinsBuild
+    .\gradlew installer windowsZip -PtoolChainPath="$comp" -PjenkinsBuild
 } else {
-    .\gradlew installer -PtoolChainPath="$comp"
+    .\gradlew installer windowsZip -PtoolChainPath="$comp"
 }

--- a/buildInstaller.ps1
+++ b/buildInstaller.ps1
@@ -42,4 +42,8 @@ Write-Host "Installed InnoSetup 5.5.9" -ForegroundColor Green
 $env:PATH += ";C:\Program Files (x86)\Inno Setup 5"
 $env:PATH += ";C:\Program Files\Inno Setup 5"
 
-.\gradlew installer -PtoolChainPath=$comp
+if ($env:APPVEYOR) {
+    .\gradlew installer -PtoolChainPath=$comp -PjenkinsBuild
+} else {
+    .\gradlew installer -PtoolChainPath=$comp
+}

--- a/buildInstaller.ps1
+++ b/buildInstaller.ps1
@@ -1,3 +1,34 @@
+
+if ($env:APPVEYOR) {
+    $localFolder = "$env:APPVEYOR_BUILD_FOLDER\temp"
+} else {
+    $localFolder = ".\temp"
+}
+
+# Create temp directory to store stuff in
+if ((Test-Path $localFolder) -eq $false) {
+  md $localFolder
+}
+
+$compilerName = "compiler"
+
+echo "Downloading Compiler"
+(New-Object System.Net.WebClient).DownloadFile("http://first.wpi.edu/FRC/roborio/toolchains/FRC-2017-Windows-Toolchain-4.9.3.zip", "$localFolder\$compilerName.zip")
+
+# unzip everything
+Add-Type -assembly "system.io.compression.filesystem"
+
+function Unzip($file)
+{
+  [io.compression.zipfile]::ExtractToDirectory("$localFolder\$file.zip", "$localFolder\$file")
+}
+
+echo "Extracting Compiler"
+Unzip($compilerName)
+
+echo "Adding compiler to path"
+$comp = "$localFolder\compiler\frc\bin"
+
 $exePath = "$env:USERPROFILE\innosetup-5.5.9-unicode.exe"
  
 Write-Host "Downloading InnoSetup 5.5.9..."
@@ -11,4 +42,4 @@ Write-Host "Installed InnoSetup 5.5.9" -ForegroundColor Green
 $env:PATH += ";C:\Program Files (x86)\Inno Setup 5"
 $env:PATH += ";C:\Program Files\Inno Setup 5"
 
-.\gradlew installer
+.\gradlew installer -PtoolChainPath=$comp

--- a/buildInstaller.ps1
+++ b/buildInstaller.ps1
@@ -43,7 +43,7 @@ $env:PATH += ";C:\Program Files (x86)\Inno Setup 5"
 $env:PATH += ";C:\Program Files\Inno Setup 5"
 
 if ($env:APPVEYOR) {
-    .\gradlew installer -PtoolChainPath=$comp -PjenkinsBuild
+    .\gradlew installer -PtoolChainPath="$comp" -PjenkinsBuild
 } else {
-    .\gradlew installer -PtoolChainPath=$comp
+    .\gradlew installer -PtoolChainPath="$comp"
 }

--- a/cpp.gradle
+++ b/cpp.gradle
@@ -13,7 +13,6 @@ def cppSetupModel = { project ->
                 binaries.all {
                     tasks.withType(CppCompile) {
                         cppCompiler.args "-DNAMESPACED_WPILIB"
-                        addUserLinks(linker, targetPlatform, false)
                         addHalLibraryLinks(it, linker, targetPlatform)
                         addWpiUtilLibraryLinks(it, linker, targetPlatform)
                         addNetworkTablesLibraryLinks(it, linker, targetPlatform)

--- a/installer.gradle
+++ b/installer.gradle
@@ -1,33 +1,9 @@
-task javaSourceJar(type: Jar) {
-    description = 'Generates the source jar for java'
-    group = 'WPILib'
-    baseName = libraryName
-    classifier = "sources"
-    duplicatesStrategy = 'exclude'
-    destinationDir = releaseDir
+def setupDir = file("${rootDir}/setup")
 
-    dependsOn project(':arm:java').classes
-    from project(':arm:java').sourceSets.main.allJava
-}
-
-task javaJavadocJar(type: Jar) {
-    description = 'Generates the javadoc jar for java'
-    group = 'WPILib'
-    baseName = libraryName
-    classifier = "javadoc"
-    duplicatesStrategy = 'exclude'
-    destinationDir = releaseDir
-    
-    dependsOn project(':arm:java').javadoc
-    from project(':arm:java').javadoc.destinationDir
-}
-
-task userStaticZip(type: Zip) {
+task copyForSetup(type: Copy) {
     description = 'Creates user zip of libraries, with static c++ libs.'
     group = 'WPILib'
-    destinationDir = releaseDir
-    baseName = libraryName
-    classifier = 'user'
+    destinationDir = setupDir
     duplicatesStrategy = 'exclude'
     
     // Copy include files from cpp project
@@ -161,61 +137,40 @@ task userStaticZip(type: Zip) {
     }
 }
 
-task cppSources(type: Zip) {
-    description = 'Creates a zip of cpp sources.'
-    group = 'WPILib'
-    destinationDir = releaseDir
-    baseName = libraryName
-    classifier = 'cppsources'
-    duplicatesStrategy = 'exclude'
-    
-    from(cppSrc) {
-        into 'src'
-    }
-
-    from(cppInclude) {
-        into 'include'
-    }
-}
-
-if (useDriver) {
-    task driverSources(type: Zip) {
-        description = 'Creates a zip of driver sources.'
-        group = 'WPILib'
-        destinationDir = releaseDir
-        baseName = libraryName
-        classifier = 'driversources'
-        duplicatesStrategy = 'exclude'
-        
-        from(driverSrc) {
-            into 'src'
-        }
-
-        from(driverInclude) {
-            into 'include'
-        }
-    }
-}
-
-tasks.whenTaskAdded { task ->
+project(':arm:cpp').tasks.whenTaskAdded { task ->
     def name = task.name.toLowerCase()
     if (name.contains("sharedlibrary") || name.contains("staticlibrary")) {
-        userStaticZip.dependsOn task
+        copyForSetup.dependsOn task
     }
 }
 
-tasks.whenTaskAdded { task ->
+project(':arm:java').tasks.whenTaskAdded { task ->
     def name = task.name.toLowerCase()
     if (name.contains("sharedlibrary") || name.contains("staticlibrary")) {
-        userStaticZip.dependsOn task
+        copyForSetup.dependsOn task
     }
 }
 
+// https://github.com/syncany/syncany/tree/master/gradle/innosetup
+// Skeleton code found here
+task installer() {
+    dependsOn copyForSetup
 
-build.dependsOn javaSourceJar
-build.dependsOn javaJavadocJar
-build.dependsOn userStaticZip
-build.dependsOn cppSources
-if (useDriver) {
-    build.dependsOn driverSources
+    doLast {
+        delete "${setupDir}/setup.iss"
+
+        copy {
+            from("${rootDir}/setup.iss.skel")
+            rename("setup.iss.skel", "setup.iss")
+            expand([
+            applicationVersion: "${WPILibVersion.version}"
+            ])
+            into(setupDir)
+        }
+
+        exec {
+            workingDir rootDir
+            commandLine "iscc ${setupDir}/setup.iss".split()
+        }
+    }
 }

--- a/installer.gradle
+++ b/installer.gradle
@@ -1,4 +1,4 @@
-def setupDir = file("${rootDir}/setup")
+ext.setupDir = file("${rootDir}/setup")
 
 task copyForSetup(type: Copy) {
     description = 'Creates user zip of libraries, with static c++ libs.'

--- a/installer.gradle
+++ b/installer.gradle
@@ -151,6 +151,15 @@ project(':arm:java').tasks.whenTaskAdded { task ->
     }
 }
 
+task windowsZip(type: Copy) {
+    dependsOn userStaticZip
+    destinationDir = file("${setupDir}/output")
+
+    from (userStaticZip.outputs.files.singleFile) {
+        rename("(.*).zip", "WPINIVisionWrapper_${(WPILibVersion.version).replace(".", "_")}.zip") 
+    }
+}
+
 // https://github.com/syncany/syncany/tree/master/gradle/innosetup
 // Skeleton code found here
 task installer() {

--- a/java/java.gradle
+++ b/java/java.gradle
@@ -16,7 +16,6 @@ def cppSetupModel = { project ->
 
                 binaries.all {
                     tasks.withType(CppCompile) {
-                        addUserLinks(linker, targetPlatform, false)
                         addHalLibraryLinks(it, linker, targetPlatform)
                         addWpiUtilLibraryLinks(it, linker, targetPlatform)
                     }

--- a/releases.gradle
+++ b/releases.gradle
@@ -159,6 +159,10 @@ task userStaticZip(type: Zip) {
             into "/cpp/src/$libraryName"
         }
     }
+
+    from(file("${rootDir}/examples")) {
+        into '/examples'
+    }
 }
 
 task cppSources(type: Zip) {
@@ -197,14 +201,14 @@ if (useDriver) {
     }
 }
 
-tasks.whenTaskAdded { task ->
+project(':arm:cpp').tasks.whenTaskAdded { task ->
     def name = task.name.toLowerCase()
     if (name.contains("sharedlibrary") || name.contains("staticlibrary")) {
         userStaticZip.dependsOn task
     }
 }
 
-tasks.whenTaskAdded { task ->
+project(':arm:java').tasks.whenTaskAdded { task ->
     def name = task.name.toLowerCase()
     if (name.contains("sharedlibrary") || name.contains("staticlibrary")) {
         userStaticZip.dependsOn task

--- a/setup.iss.skel
+++ b/setup.iss.skel
@@ -3,8 +3,7 @@
 
 #define MyAppName "WPI NIVision Library Wrapper"
 #define MyAppShortName "WPINIVisionWrapper"
-#define MyAppVersion "1.0.0"
-#define MyAppPublisher "WPI\FIRST"
+#define MyAppPublisher "WPI\\FIRST"
 #define MyAppURL "http://www.firstinspires.org"
 
 
@@ -14,16 +13,16 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{0B03C4FA-07C4-4E22-AC6C-557ECD61D9CD}
 AppName={#MyAppName}
-AppVersion={#MyAppVersion}
+AppVersion=${applicationVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={%USERPROFILE}\wpilib\user
+DefaultDirName={%USERPROFILE}\\wpilib\\user
 UninstallDisplayName=Uninstall_{#MyAppName}
 DefaultGroupName={#MyAppName}
-OutputBaseFilename=setup
+OutputBaseFilename=WPINIVisionWrapper_${applicationVersion}
 Compression=lzma
 SolidCompression=yes
 Uninstallable=no
@@ -32,8 +31,8 @@ Uninstallable=no
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "\release\cpp\*"; DestDIR: "{app}\cpp"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "\release\java\*"; DestDIR: "{app}\java"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "\examples\*"; DestDir: "{app}\NIVision_examples"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "cpp\\*"; DestDIR: "{app}\\cpp"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "java\\*"; DestDIR: "{app}\\java"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\\examples\\*"; DestDir: "{app}\\NIVision_examples"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 


### PR DESCRIPTION
Using the buildInstaller.ps1 powershell script will download the compiler, download the installer build program, and build a version of the installer. When ran on AppVeyor, will publish the builds to the AppVeyor artifacts page, and on a git tag, will push the release to the tag to automatically create the release. So all that will be required to run a build will just be properly tagging the repo. 

Note the publishing will not work properly until AppVeyor gets set up, and the API key in appveyor.yml gets updated to one for the frcjenkins AppVeyor account. But everything else works.

Sorry no linux installer build yet. 